### PR TITLE
Player camera position controllable via game state

### DIFF
--- a/apps/explorers-game-web/src/components/ScenePanel.tsx
+++ b/apps/explorers-game-web/src/components/ScenePanel.tsx
@@ -78,14 +78,22 @@ const SceneManager = () => {
 
 const ChannelScene = () => {
   // render a box if there is a game...
-  const { roomEntity } = useContext(ChannelContext);
+  const { roomEntity, connectionEntity, sessionEntity } =
+    useContext(ChannelContext);
   const currentGameInstanceId = useEntitySelector(
     roomEntity,
     (entity) => entity.currentGameInstanceId
   );
+  const currentUserInstanceId = useEntitySelector(
+    sessionEntity,
+    (entity) => entity.userId
+  );
 
   return currentGameInstanceId ? (
-    <StrikersSceneManager gameInstanceId={currentGameInstanceId} />
+    <StrikersSceneManager
+      gameInstanceId={currentGameInstanceId}
+      currentUserInstanceId={currentUserInstanceId}
+    />
   ) : (
     <>
       <OrbitControls />

--- a/games/strikers/src/client/components/camera-rig.context.tsx
+++ b/games/strikers/src/client/components/camera-rig.context.tsx
@@ -10,27 +10,41 @@ import {
   useState,
 } from 'react';
 import CameraControlsImpl from 'camera-controls';
+import { StrikersCameraPosition } from '@schema/types';
 
 // CameraControlsImpl.install({ THREE: THREE });
 
 export const CameraRigContext = createContext(
-  {} as { cameraControls: CameraControls }
+  {} as {
+    cameraControls: CameraControls;
+  }
 );
 
 export const CameraRigProvider: FC<{
   children: ReactNode;
   grid: Grid<Hex>;
-}> = ({ children, grid }) => {
+  playerCameraPosition: StrikersCameraPosition;
+}> = ({ children, playerCameraPosition }) => {
   const cameraControlsRef = useRef<CameraControls | null>(null);
   const [cameraControls, setCameraControls] = useState<CameraControls | null>(
     null
   );
 
   // todo fix this extra re-render, better way to do this
-  // had troupble instantiating CameraControlsImpl directly
+  // had trouble instantiating CameraControlsImpl directly
   useEffect(() => {
     setCameraControls(cameraControlsRef.current);
   }, [cameraControlsRef.current]);
+
+  // When server-controlled camera position changes, update client-side camera
+  useEffect(() => {
+    if (!cameraControls) {
+      return;
+    }
+    const { x, y, z, targetX, targetY, targetZ } = playerCameraPosition;
+    console.log('setting camera pos to ', playerCameraPosition);
+    cameraControls.setLookAt(x, y, z, targetX, targetY, targetZ, true);
+  }, [cameraControls, playerCameraPosition]);
 
   return (
     <>

--- a/games/strikers/src/client/components/field.stories.tsx
+++ b/games/strikers/src/client/components/field.stories.tsx
@@ -1,7 +1,7 @@
 import { SunsetSky } from '@3d/sky';
 import { Canvas } from '@react-three/fiber';
 import { Meta, StoryObj } from '@storybook/react';
-import { Goal } from "./goal";
+import { Goal } from './goal';
 import { Grid, defineHex, rectangle } from 'honeycomb-grid';
 import { useControls } from 'leva';
 import { atom } from 'nanostores';
@@ -44,7 +44,7 @@ export const Default: Story = {
     const { cameraControls } = useContext(CameraRigContext);
 
     useEffect(() => {
-      cameraControls.setLookAt(0, 10, 50, 0, 0, -20, true);
+      // cameraControls.setLookAt(0, 10, 50, 0, 0, -20, true);
     }, [cameraControls]);
 
     return (

--- a/games/strikers/src/client/scene-manager.tsx
+++ b/games/strikers/src/client/scene-manager.tsx
@@ -83,17 +83,18 @@ const GameScene = () => {
     return cell;
   });
   const { gameEntity, strikersPlayerEntity } = useContext(StrikersContext);
-  console.log({ gameEntity });
+  console.log({ gameEntity, strikersPlayerEntity });
   const players = useEntitySelector(
     gameEntity,
     (entity) => entity.gameState.players
   );
+  const playerCameraPosition = useEntitySelector(
+    strikersPlayerEntity,
+    (entity) => entity.cameraPosition
+  );
 
   return (
-    <CameraRigProvider
-      grid={grid}
-      playerCameraPosition={strikersPlayerEntity.cameraPosition}
-    >
+    <CameraRigProvider grid={grid} playerCameraPosition={playerCameraPosition}>
       {/* <MapControls screenSpacePanning={true} /> */}
       <axesHelper />
       <SunsetSky />

--- a/games/strikers/src/server/entities/strikers-game.ts
+++ b/games/strikers/src/server/entities/strikers-game.ts
@@ -11,6 +11,7 @@ import {
 import { assert, assertEntitySchema } from '@explorers-club/utils';
 import type {
   CreateEventProps,
+  SnowflakeId,
   StrikersBoard,
   StrikersBoardCard,
   StrikersCard,

--- a/games/strikers/src/server/entities/strikers-player.ts
+++ b/games/strikers/src/server/entities/strikers-player.ts
@@ -1,39 +1,56 @@
 import {
-    Entity,
-    StrikersPlayerCommand,
-    StrikersPlayerContext,
-    StrikersPlayerMachine,
-    WithSenderId,
-  } from '@explorers-club/schema';
-  import { assertEntitySchema } from '@explorers-club/utils';
-  import { World } from 'miniplex';
-  import { createMachine } from 'xstate';
-  
-  export const createStrikersPlayerMachine = ({
-    world,
-    entity,
-  }: {
-    world: World;
-    entity: Entity;
-  }) => {
-    assertEntitySchema(entity, 'strikers_player');
-  
-    return createMachine({
-      id: 'StrikersPlayerMachine',
-      type: 'parallel',
-      schema: {
-        context: {} as StrikersPlayerContext,
-        events: {} as WithSenderId<StrikersPlayerCommand>,
-      },
-      states: {
-        Active: {
-          initial: "False",
-          states: {
-            False: {},
-            True: {}
-          }
+  Entity,
+  StrikersPlayerCommand,
+  StrikersPlayerContext,
+  StrikersPlayerMachine,
+  WithSenderId,
+} from '@explorers-club/schema';
+import { assertEntitySchema } from '@explorers-club/utils';
+import { World } from 'miniplex';
+import { createMachine } from 'xstate';
+
+export const createStrikersPlayerMachine = ({
+  world,
+  entity,
+}: {
+  world: World;
+  entity: Entity;
+}) => {
+  assertEntitySchema(entity, 'strikers_player');
+
+  return createMachine({
+    id: 'StrikersPlayerMachine',
+    type: 'parallel',
+    schema: {
+      context: {} as StrikersPlayerContext,
+      events: {} as WithSenderId<StrikersPlayerCommand>,
+    },
+    states: {
+      Active: {
+        initial: 'False',
+        states: {
+          False: {},
+          True: {},
+        },
+        on: {
+          CHANGE_CAMERA_POSITION: {
+            actions: async (_, event) => {
+              switch (event.cameraPosition) {
+                case 'BirdsEye':
+                  entity.cameraPosition = {
+                    x: 0,
+                    y: entity.cameraPosition.y - 10,
+                    z: 0,
+                    targetX: 0,
+                    targetY: 0,
+                    targetZ: 0,
+                  };
+                  break;
+              }
+            },
+          },
         },
       },
-    }) satisfies StrikersPlayerMachine;
-  };
-  
+    },
+  }) satisfies StrikersPlayerMachine;
+};

--- a/games/strikers/src/server/index.ts
+++ b/games/strikers/src/server/index.ts
@@ -35,16 +35,27 @@ export const createStrikersGame = (
   const p2UserEntity = entitiesById.get(lobbyConfig.p2UserId);
   assertEntitySchema(p2UserEntity, 'user');
 
+  const defaultCameraPosition = {
+    x: 0,
+    y: 10,
+    z: 120,
+    targetX: 0,
+    targetY: 0,
+    targetZ: -20,
+  };
+
   const p1PlayerEntity = createEntity<StrikersPlayerEntity>({
     schema: 'strikers_player',
     userId: p1UserEntity.id,
     gameEntityId,
+    cameraPosition: defaultCameraPosition,
   });
 
   const p2PlayerEntity = createEntity<StrikersPlayerEntity>({
     schema: 'strikers_player',
     userId: p2UserEntity.id,
     gameEntityId,
+    cameraPosition: defaultCameraPosition,
   });
 
   const cards = [

--- a/libs/components/src/organisms/channel/channel.context.tsx
+++ b/libs/components/src/organisms/channel/channel.context.tsx
@@ -1,5 +1,9 @@
 import { WorldContext } from '@context/WorldProvider';
-import { ConnectionEntity, RoomEntity } from '@explorers-club/schema';
+import {
+  ConnectionEntity,
+  RoomEntity,
+  SessionEntity,
+} from '@explorers-club/schema';
 import { useCreateEntityStore } from '@hooks/useCreateEntityStore';
 import { useEntityStoreSelector } from '@hooks/useEntityStoreSelector';
 import { useStore } from '@nanostores/react';
@@ -9,12 +13,14 @@ export const ChannelContext = createContext(
   {} as {
     connectionEntity: ConnectionEntity;
     roomEntity: RoomEntity;
+    sessionEntity: SessionEntity;
   }
 );
 
 export const ChannelProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const { entityStoreRegistry } = useContext(WorldContext);
   const connectionEntity = useStore(entityStoreRegistry.myConnectionEntity);
+  const sessionEntity = useStore(entityStoreRegistry.mySessionEntity);
   const currentChannelId = useEntityStoreSelector(
     entityStoreRegistry.myConnectionEntity,
     (entity) => entity.currentChannelId
@@ -29,13 +35,15 @@ export const ChannelProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   const roomEntity = useStore(roomEntityStore);
 
-  if (!roomEntity || !connectionEntity) {
+  if (!roomEntity || !connectionEntity || !sessionEntity) {
     // todo loading component injected
     return <></>;
   }
 
   return (
-    <ChannelContext.Provider value={{ connectionEntity, roomEntity }}>
+    <ChannelContext.Provider
+      value={{ connectionEntity, roomEntity, sessionEntity }}
+    >
       {children}
     </ChannelContext.Provider>
   );

--- a/libs/components/src/organisms/chat/chat.component.tsx
+++ b/libs/components/src/organisms/chat/chat.component.tsx
@@ -69,13 +69,13 @@ const ChatInput: FC<{ disabled: boolean }> = ({ disabled }) => {
 
       if (text !== '') {
         // todo send
-        // roomEntity.send({
-        //   type: 'MESSAGE',
-        //   message: {
-        //     type: 'PLAIN_MESSAGE',
-        //     text,
-        //   },
-        // });
+        roomEntity.send({
+          type: 'MESSAGE',
+          message: {
+            type: 'PLAIN_MESSAGE',
+            text,
+          },
+        });
 
         // send({ type: 'MESSAGE', message: { text } });
 

--- a/libs/schema/src/games/strikers.ts
+++ b/libs/schema/src/games/strikers.ts
@@ -85,6 +85,12 @@ const LeaveCommandSchema = z.object({
   type: z.literal('LEAVE'),
 });
 
+const ChangeCameraPositionCommandSchema = z.object({
+  type: z.literal('CHANGE_CAMERA_POSITION'),
+  cameraPosition: z.enum(['BirdsEye']),
+  senderId: SnowflakeIdSchema,
+});
+
 export const StrikersGameCommandSchema = z.union([
   StartCommandSchema,
   LeaveCommandSchema,
@@ -406,6 +412,7 @@ export const StrikersPlayerStateValueSchema = z.object({
 export const StrikersPlayerCommandSchema = z.union([
   StartCommandSchema,
   LeaveCommandSchema,
+  ChangeCameraPositionCommandSchema,
 ]);
 
 export const StrikersPlayerEntitySchema = EntityBaseSchema(

--- a/libs/schema/src/games/strikers.ts
+++ b/libs/schema/src/games/strikers.ts
@@ -382,11 +382,21 @@ export const StrikersTurnContextSchema = z.object({
   foo: z.string(),
 });
 
+export const StrikersCameraPositionSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+  targetX: z.number(),
+  targetY: z.number(),
+  targetZ: z.number(),
+});
+
 const StrikersPlayerEntityPropSchema = z.object({
   schema: StrikersPlayerSchemaTypeLiteral,
   gameEntityId: SnowflakeIdSchema,
   userId: SnowflakeIdSchema,
   // channel: z.custom<Observable<MessageEvent>>(),
+  cameraPosition: StrikersCameraPositionSchema,
 });
 
 export const StrikersPlayerStateValueSchema = z.object({

--- a/libs/schema/src/lib/room.ts
+++ b/libs/schema/src/lib/room.ts
@@ -39,12 +39,21 @@ const LeaveCommandSchema = z.object({
   type: z.literal('LEAVE'),
 });
 
+const MessageCommandSchema = z.object({
+  type: z.literal('MESSAGE'),
+  message: z.object({
+    type: z.literal('PLAIN_MESSAGE'), // Todo: other types
+    text: z.string(),
+  }),
+});
+
 export const RoomCommandSchema = z.union([
   ConnectCommandSchema,
   DisconnectCommandSchema,
   JoinCommandSchema,
   StartCommandSchema,
   LeaveCommandSchema,
+  MessageCommandSchema,
 ]);
 
 export const RoomEntityPropsSchema = z.object({

--- a/libs/schema/src/types.ts
+++ b/libs/schema/src/types.ts
@@ -45,6 +45,7 @@ import {
   CodebreakersPlayerStateValueSchema,
 } from './games/codebreakers';
 import {
+  StrikersCameraPositionSchema,
   StrikersBoardCardSchema,
   StrikersEffectCommandSchema,
   StrikersEffectContextSchema,
@@ -691,6 +692,9 @@ export type StrikersPlayerMachine = StateMachine<
   StrikersPlayerContext,
   StrikersPlayerStateSchema,
   WithSenderId<StrikersPlayerCommand>
+>;
+export type StrikersCameraPosition = z.infer<
+  typeof StrikersCameraPositionSchema
 >;
 
 export type StrikersEffectEntity = z.infer<typeof StrikersEffectEntitySchema>;


### PR DESCRIPTION
- Make it so that a StrikersPlayer camera position can be controlled via game state
- Set a camera position when the game is initialized
- Update the camera position when a player types `BIRDS_EYE` into the chat

This seems to almost work, but there's an issue where the game scene isn't re-rendering after the StrikerPlayer's cameraPosition gets updated. 